### PR TITLE
Nick's suggestions

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ The input of the SPC tool is a list of the Middle Layer Super Output Area
 (MSOAs) where you want to create a spatially enriched sythetic population to
 feed other dynamic models. SPC includes a script to assist you with the proper
 list of the MSOAs by defining a Local Authority District area in England. [Get
-started](https://alan-turing-institute.github.io/uatk-spc/getting_started.html)
+started](https://alan-turing-institute.github.io/uatk-spc/)
 to download SPC data or run the tool in different MSOAs.
 
 ## Lineage


### PR DESCRIPTION
- Fixed 'Get started' link in the [readme](https://github.com/nickmalleson/uatk-spc/blob/main/README.md) that pointed to a non-existant page (https://alan-turing-institute.github.io/uatk-spc/getting_started.html)  (https://github.com/alan-turing-institute/uatk-spc/pull/24/commits/28b44c4d48b4cbb7e157a3a6c278e135396579c9)