### PR TITLE
Make proto output deterministic

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -45,12 +45,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "904dfeac50f3cdaba28fc6f57fdcddb75f49ed61346676a78c4ffe55877802fd"
 
 [[package]]
-name = "base64ct"
-version = "1.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c3c1a368f70d6cf7302d78f8f7093da241fb8e8807c05cc9e51a125895a6d5b"
-
-[[package]]
 name = "bincode"
 version = "1.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -750,6 +744,12 @@ name = "hermit-abi"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fed44880c466736ef9a5c5b5facefb5ed0785676d0c02d612db14e54f0d84286"
+
+[[package]]
+name = "hex"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "http"
@@ -1833,7 +1833,6 @@ name = "spc"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "base64ct",
  "bincode",
  "bytes",
  "cap",
@@ -1846,6 +1845,7 @@ dependencies = [
  "futures-util",
  "geo",
  "geojson",
+ "hex",
  "indicatif",
  "ndarray",
  "ndarray-npy",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -45,6 +45,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "904dfeac50f3cdaba28fc6f57fdcddb75f49ed61346676a78c4ffe55877802fd"
 
 [[package]]
+name = "base64ct"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c3c1a368f70d6cf7302d78f8f7093da241fb8e8807c05cc9e51a125895a6d5b"
+
+[[package]]
 name = "bincode"
 version = "1.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -68,7 +74,16 @@ dependencies = [
  "block-padding",
  "byte-tools",
  "byteorder",
- "generic-array",
+ "generic-array 0.12.4",
+]
+
+[[package]]
+name = "block-buffer"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array 0.14.7",
 ]
 
 [[package]]
@@ -222,6 +237,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5827cebf4670468b8772dd191856768aedcb1b0278a04f989f7766351917b9dc"
 
 [[package]]
+name = "cpufeatures"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e4c1eaa2012c47becbbad2ab175484c2a84d1185b566fb2cc5b8707343dfe58"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "crc32fast"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -282,6 +306,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "crypto-common"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
+dependencies = [
+ "generic-array 0.14.7",
+ "typenum",
+]
+
+[[package]]
 name = "csv"
 version = "1.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -332,7 +366,17 @@ version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f3d0c8c8752312f9713efd397ff63acb9f85585afbf179282e720e7704954dd5"
 dependencies = [
- "generic-array",
+ "generic-array 0.12.4",
+]
+
+[[package]]
+name = "digest"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8168378f4e5023e7218c89c891c0fd8ecdb5e5e4f18cb78f38cf245dd021e76f"
+dependencies = [
+ "block-buffer 0.10.4",
+ "crypto-common",
 ]
 
 [[package]]
@@ -389,6 +433,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "errno"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4bcfec3a70f97c962c307b2d2c56e358cf1d00b558d74262b5f929ee8cc7e73a"
+dependencies = [
+ "errno-dragonfly",
+ "libc",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
 name = "errno-dragonfly"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -421,7 +476,7 @@ checksum = "975ccf83d8d9d0d84682850a38c8169027be83368805971cc4f238c2b245bc98"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall",
+ "redox_syscall 0.2.13",
  "winapi",
 ]
 
@@ -546,6 +601,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ffdf9f34f1447443d37393cc6c2b8313aebddcd96906caf34e54c68d8e57d7bd"
 dependencies = [
  "typenum",
+]
+
+[[package]]
+name = "generic-array"
+version = "0.14.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+dependencies = [
+ "typenum",
+ "version_check",
 ]
 
 [[package]]
@@ -681,6 +746,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "hermit-abi"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fed44880c466736ef9a5c5b5facefb5ed0785676d0c02d612db14e54f0d84286"
+
+[[package]]
 name = "http"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -795,12 +866,13 @@ dependencies = [
 
 [[package]]
 name = "io-lifetimes"
-version = "1.0.3"
+version = "1.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46112a93252b123d31a119a8d1a1ac19deac4fac6e0e8b0df58f0d4e5870e63c"
+checksum = "9c66c74d2ae7e79a5a8f7ac924adbe38ee42a859c6539ad869eb51f0b52dc220"
 dependencies = [
+ "hermit-abi 0.3.1",
  "libc",
- "windows-sys 0.42.0",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -817,7 +889,7 @@ checksum = "28dfb6c8100ccc63462345b67d1bbc3679177c75ee4bf59bf29c8b1d110b8189"
 dependencies = [
  "hermit-abi 0.2.6",
  "io-lifetimes",
- "rustix",
+ "rustix 0.36.6",
  "windows-sys 0.42.0",
 ]
 
@@ -859,9 +931,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.139"
+version = "0.2.142"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "201de327520df007757c1f0adce6e827fe8562fbc28bfd9c15571c66ca1f5f79"
+checksum = "6a987beff54b60ffa6d51982e1aa1146bc42f19bd26be28b0586f252fccf5317"
 
 [[package]]
 name = "libm"
@@ -874,6 +946,12 @@ name = "linux-raw-sys"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f051f77a7c8e6957c0696eac88f26b0117e54f52d3fc682ab19397a8812846a4"
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "36eb31c1778188ae1e64398743890d0877fef36d11521ac60406b42016e8c2cf"
 
 [[package]]
 name = "lock_api"
@@ -1169,7 +1247,7 @@ checksum = "995f667a6c822200b0433ac218e05582f0e2efa1b922a3fd2fbaadc5f87bab37"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall",
+ "redox_syscall 0.2.13",
  "smallvec",
  "windows-sys 0.34.0",
 ]
@@ -1461,6 +1539,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "redox_syscall"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "567664f262709473930a4bf9e51bf2ebf3348f2e748ccc50dea20646858f8f29"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
 name = "regex"
 version = "1.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1480,15 +1567,6 @@ name = "regex-syntax"
 version = "0.6.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f497285884f3fcff424ffc933e56d7cbca511def0c9831a7f9b5f6153e3cc89b"
-
-[[package]]
-name = "remove_dir_all"
-version = "0.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3acd125665422973a33ac9d3dd2df85edad0f4ae9b00dafb1a05e43a9f5ef8e7"
-dependencies = [
- "winapi",
-]
 
 [[package]]
 name = "reqwest"
@@ -1561,11 +1639,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4feacf7db682c6c329c4ede12649cd36ecab0f3be5b7d74e6a20304725db4549"
 dependencies = [
  "bitflags",
- "errno",
+ "errno 0.2.8",
  "io-lifetimes",
  "libc",
- "linux-raw-sys",
+ "linux-raw-sys 0.1.4",
  "windows-sys 0.42.0",
+]
+
+[[package]]
+name = "rustix"
+version = "0.37.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0661814f891c57c930a610266415528da53c4933e6dea5fb350cbfe048a9ece"
+dependencies = [
+ "bitflags",
+ "errno 0.3.1",
+ "io-lifetimes",
+ "libc",
+ "linux-raw-sys 0.3.4",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -1668,10 +1760,21 @@ version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f7d94d0bede923b3cea61f3f1ff57ff8cdfd77b400fb8f9998949e0cf04163df"
 dependencies = [
- "block-buffer",
- "digest",
+ "block-buffer 0.7.3",
+ "digest 0.8.1",
  "fake-simd",
  "opaque-debug",
+]
+
+[[package]]
+name = "sha2"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82e6b795fe2e3b1e845bafcb27aa35405c4d47cdfc92af5fc8d3002f76cebdc0"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest 0.10.6",
 ]
 
 [[package]]
@@ -1730,6 +1833,7 @@ name = "spc"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "base64ct",
  "bincode",
  "bytes",
  "cap",
@@ -1755,8 +1859,10 @@ dependencies = [
  "reqwest",
  "rstar",
  "serde",
+ "sha2",
  "shapefile",
  "tar",
+ "tempfile",
  "tokio",
  "tracing",
  "tracing-subscriber",
@@ -1808,16 +1914,15 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "3.3.0"
+version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5cdb1ef4eaeeaddc8fbd371e5017057064af0911902ef36b39801f67cc6d79e4"
+checksum = "b9fbec84f381d5795b08656e4912bec604d162bff9291d6189a78f4c8ab87998"
 dependencies = [
  "cfg-if",
  "fastrand",
- "libc",
- "redox_syscall",
- "remove_dir_all",
- "winapi",
+ "redox_syscall 0.3.5",
+ "rustix 0.37.15",
+ "windows-sys 0.45.0",
 ]
 
 [[package]]
@@ -2255,20 +2360,74 @@ version = "0.42.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a3e1820f08b8513f676f7ab6c1f99ff312fb97b553d30ff4dd86f9f15728aa7"
 dependencies = [
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc 0.42.0",
- "windows_i686_gnu 0.42.0",
- "windows_i686_msvc 0.42.0",
- "windows_x86_64_gnu 0.42.0",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc 0.42.0",
+ "windows_aarch64_gnullvm 0.42.2",
+ "windows_aarch64_msvc 0.42.2",
+ "windows_i686_gnu 0.42.2",
+ "windows_i686_msvc 0.42.2",
+ "windows_x86_64_gnu 0.42.2",
+ "windows_x86_64_gnullvm 0.42.2",
+ "windows_x86_64_msvc 0.42.2",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.45.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
+dependencies = [
+ "windows-targets 0.42.2",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
+dependencies = [
+ "windows-targets 0.48.0",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e5180c00cd44c9b1c88adb3693291f1cd93605ded80c250a75d472756b4d071"
+dependencies = [
+ "windows_aarch64_gnullvm 0.42.2",
+ "windows_aarch64_msvc 0.42.2",
+ "windows_i686_gnu 0.42.2",
+ "windows_i686_msvc 0.42.2",
+ "windows_x86_64_gnu 0.42.2",
+ "windows_x86_64_gnullvm 0.42.2",
+ "windows_x86_64_msvc 0.42.2",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b1eb6f0cd7c80c79759c929114ef071b87354ce476d9d94271031c0497adfd5"
+dependencies = [
+ "windows_aarch64_gnullvm 0.48.0",
+ "windows_aarch64_msvc 0.48.0",
+ "windows_i686_gnu 0.48.0",
+ "windows_i686_msvc 0.48.0",
+ "windows_x86_64_gnu 0.48.0",
+ "windows_x86_64_gnullvm 0.48.0",
+ "windows_x86_64_msvc 0.48.0",
 ]
 
 [[package]]
 name = "windows_aarch64_gnullvm"
-version = "0.42.0"
+version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41d2aa71f6f0cbe00ae5167d90ef3cfe66527d6f613ca78ac8024c3ccab9a19e"
+checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91ae572e1b79dba883e0d315474df7305d12f569b400fcf90581b06062f7e1bc"
 
 [[package]]
 name = "windows_aarch64_msvc"
@@ -2278,9 +2437,15 @@ checksum = "17cffbe740121affb56fad0fc0e421804adf0ae00891205213b5cecd30db881d"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.42.0"
+version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd0f252f5a35cac83d6311b2e795981f5ee6e67eb1f9a7f64eb4500fbc4dcdb4"
+checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2ef27e0d7bdfcfc7b868b317c1d32c641a6fe4629c171b8928c7b08d98d7cf3"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -2290,9 +2455,15 @@ checksum = "2564fde759adb79129d9b4f54be42b32c89970c18ebf93124ca8870a498688ed"
 
 [[package]]
 name = "windows_i686_gnu"
-version = "0.42.0"
+version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fbeae19f6716841636c28d695375df17562ca208b2b7d0dc47635a50ae6c5de7"
+checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "622a1962a7db830d6fd0a69683c80a18fda201879f0f447f065a3b7467daa241"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -2302,9 +2473,15 @@ checksum = "9cd9d32ba70453522332c14d38814bceeb747d80b3958676007acadd7e166956"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.42.0"
+version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84c12f65daa39dd2babe6e442988fc329d6243fdce47d7d2d155b8d874862246"
+checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4542c6e364ce21bf45d69fdd2a8e455fa38d316158cfd43b3ac1c5b1b19f8e00"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -2314,15 +2491,27 @@ checksum = "cfce6deae227ee8d356d19effc141a509cc503dfd1f850622ec4b0f84428e1f4"
 
 [[package]]
 name = "windows_x86_64_gnu"
-version = "0.42.0"
+version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf7b1b21b5362cbc318f686150e5bcea75ecedc74dd157d874d754a2ca44b0ed"
+checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca2b8a661f7628cbd23440e50b05d705db3686f894fc9580820623656af974b1"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.42.0"
+version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09d525d2ba30eeb3297665bd434a54297e4170c7f1a44cad4ef58095b4cd2028"
+checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7896dbc1f41e08872e9d5e8f8baa8fdd2677f29468c4e156210174edc7f7b953"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -2332,9 +2521,15 @@ checksum = "d19538ccc21819d01deaf88d6a17eae6596a12e9aafdbb97916fb49896d89de9"
 
 [[package]]
 name = "windows_x86_64_msvc"
-version = "0.42.0"
+version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f40009d85759725a34da6d89a94e63d7bdc50a862acf0dbc7c8e488f1edcb6f5"
+checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a515f5799fe4961cb532f983ce2b23082366b898e52ffbce459c86f67c8378a"
 
 [[package]]
 name = "winreg"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,6 +41,11 @@ typed-index-collections = { version = "3.1.0", features = ["serde-std"] }
 [build-dependencies]
 prost-build = "0.11.5"
 
+[dev-dependencies]
+base64ct={version="1.6.0", features=["alloc"]}
+sha2 = "0.10.6"
+tempfile = "3.5.0"
+
 # See https://doc.rust-lang.org/cargo/reference/profiles.html#overrides. This
 # compiles all external dependencies in release mode, yielding great runtime
 # speed, but only paying the cost of slow compilation once (since we don't

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,7 +42,7 @@ typed-index-collections = { version = "3.1.0", features = ["serde-std"] }
 prost-build = "0.11.5"
 
 [dev-dependencies]
-base64ct={version="1.6.0", features=["alloc"]}
+hex = "0.4.3"
 sha2 = "0.10.6"
 tempfile = "3.5.0"
 

--- a/build.rs
+++ b/build.rs
@@ -1,4 +1,8 @@
 fn main() -> std::io::Result<()> {
-    prost_build::compile_protos(&["src/synthpop.proto"], &["src/"])?;
+    let mut config = prost_build::Config::new();
+    // Config to use BTreeMap over HashMap for deterministic map serialization
+    // See: https://github.com/tokio-rs/prost#using-prost-in-a-no_std-crate
+    config.btree_map(["."]);
+    config.compile_protos(&["src/synthpop.proto"], &["src/"])?;
     Ok(())
 }

--- a/scripts/check_determinism.sh
+++ b/scripts/check_determinism.sh
@@ -8,6 +8,9 @@
 #
 # If files differ, the protobuf are converted to sorted JSON to get diff.
 
+# Exit upon error
+set -e
+
 # Use given region
 REGION=$1
 

--- a/scripts/check_determinism.sh
+++ b/scripts/check_determinism.sh
@@ -1,5 +1,13 @@
 #!/bin/bash
 
+# Run this script from the repo root with e.g.:
+#
+#   ./scripts/check_determinism.sh rutland
+#
+# passing the region to be checked as the first positional arg.
+#
+# If files differ, the protobuf are converted to sorted JSON to get diff.
+
 # Use given region
 REGION=$1
 
@@ -12,12 +20,18 @@ cargo run --release -- config/England/$REGION.txt --rng-seed 0
 cp data/output/England/2020/$REGION.pb test2.pb
 
 # Get checksums
-checksum1=`shasum test1.pb | cut -f 1 -d " "`
-checksum2=`shasum test2.pb | cut -f 1 -d " "`
+hash1=`shasum -a 256 test1.pb | cut -f 1 -d " "`
+hash2=`shasum -a 256 test2.pb | cut -f 1 -d " "`
+
+printf "SHA256 hash, run 1: ${hash1}\n"
+printf "SHA256 hash, run 2: ${hash2}\n"
 
 # Compare checksums
-if [ "$checksum1" == "$checksum2" ]; then
+if [ $hash1 == $hash2 ]; then
     printf "OK\n"
+
+    # Remove temporary outputs
+    rm test1.pb test2.pb
 else
     printf "Error: protobuf outputs differ.\n"
 
@@ -27,4 +41,7 @@ else
 
     # Sort JSON and get diff
     diff <(jq --sort-keys . test1.json) <(jq --sort-keys . test2.json)
+
+    # Remove temporary outputs
+    rm test1.pb test2.pb test1.json test2.json
 fi

--- a/src/init/commuting.rs
+++ b/src/init/commuting.rs
@@ -1,4 +1,4 @@
-use std::collections::{BTreeMap, BTreeSet, HashMap};
+use std::collections::{BTreeMap, BTreeSet};
 
 use anyhow::Result;
 use fs_err::File;

--- a/src/init/commuting.rs
+++ b/src/init/commuting.rs
@@ -76,16 +76,16 @@ struct Row {
 }
 
 struct Businesses {
-    venues_per_sic: HashMap<u32, Vec<VenueID>>,
-    available_jobs: HashMap<VenueID, usize>,
+    venues_per_sic: BTreeMap<u32, Vec<VenueID>>,
+    available_jobs: BTreeMap<VenueID, usize>,
     venues: TiVec<VenueID, Venue>,
 }
 
 impl Businesses {
     fn load(msoas: BTreeSet<MSOA>) -> Result<Businesses> {
         let mut result = Businesses {
-            venues_per_sic: HashMap::new(),
-            available_jobs: HashMap::new(),
+            venues_per_sic: BTreeMap::new(),
+            available_jobs: BTreeMap::new(),
             venues: TiVec::new(),
         };
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -51,6 +51,7 @@ pub struct Population {
     pub year: u32,
 }
 
+#[derive(Clone)]
 pub struct Input {
     pub year: u32,
     pub enable_commuting: bool,

--- a/test_determinism.sh
+++ b/test_determinism.sh
@@ -1,12 +1,30 @@
 #!/bin/bash
 
-cargo run --release -- config/England/rutland.txt --rng-seed 0
-cp data/output/England/2020/rutland.pb test1.pb
-cargo run --release -- config/England/rutland.txt --rng-seed 0
-cp data/output/England/2020/rutland.pb test2.pb
-diff test1.pb test2.pb
+# Use given region
+REGION=$1
 
-python python/protobuf_to_json.py test1.pb > test1.json
-python python/protobuf_to_json.py test2.pb > test2.json
+# Run 1
+cargo run --release -- config/England/$REGION.txt --rng-seed 0
+cp data/output/England/2020/$REGION.pb test1.pb
 
-diff <(jq --sort-keys . test1.json) <(jq --sort-keys . test2.json)
+# Run 2
+cargo run --release -- config/England/$REGION.txt --rng-seed 0
+cp data/output/England/2020/$REGION.pb test2.pb
+
+# Get checksums
+checksum1=`shasum test1.pb | cut -f 1 -d " "`
+checksum2=`shasum test2.pb | cut -f 1 -d " "`
+
+# Compare checksums
+if [ "$checksum1" == "$checksum2" ]; then
+    printf "OK\n"
+else
+    printf "Error: protobuf outputs differ.\n"
+
+    # Convert to JSON
+    python python/protobuf_to_json.py test1.pb > test1.json
+    python python/protobuf_to_json.py test2.pb > test2.json
+
+    # Sort JSON and get diff
+    diff <(jq --sort-keys . test1.json) <(jq --sort-keys . test2.json)
+fi

--- a/test_determinism.sh
+++ b/test_determinism.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+cargo run --release -- config/England/rutland.txt --rng-seed 0
+cp data/output/England/2020/rutland.pb test1.pb
+cargo run --release -- config/England/rutland.txt --rng-seed 0
+cp data/output/England/2020/rutland.pb test2.pb
+diff test1.pb test2.pb
+
+python python/protobuf_to_json.py test1.pb > test1.json
+python python/protobuf_to_json.py test2.pb > test2.json
+
+diff <(jq --sort-keys . test1.json) <(jq --sort-keys . test2.json)

--- a/tests/determinism.rs
+++ b/tests/determinism.rs
@@ -1,11 +1,13 @@
+use std::collections::BTreeSet;
+use std::io::{BufRead, BufReader};
+
 use anyhow::Result;
 use fs_err::File;
 use rand::rngs::StdRng;
 use rand::SeedableRng;
 use sha2::{Digest, Sha256};
+
 use spc::{protobuf, Input, Population, MSOA};
-use std::collections::BTreeSet;
-use std::io::{BufRead, BufReader};
 
 // Gets the hex encoded SHA256 hash from a generated population protobuf output given input and rng.
 async fn population_protobuf_hash(input: &Input, dir: &str, mut rng: StdRng) -> Result<String> {

--- a/tests/determinism.rs
+++ b/tests/determinism.rs
@@ -1,5 +1,4 @@
 use anyhow::Result;
-use base64ct::{Base64, Encoding};
 use fs_err::File;
 use rand::rngs::StdRng;
 use rand::SeedableRng;
@@ -8,15 +7,13 @@ use spc::{protobuf, Input, Population, MSOA};
 use std::collections::BTreeSet;
 use std::io::{BufRead, BufReader};
 
-// Generates the file hash from a generated population protobuf output given input and seed.
-async fn population_protobuf_hash(input: &Input, dir: &str, mut seed: StdRng) -> Result<String> {
-    let (population, _) = Population::create(input.clone(), &mut seed).await?;
+// Gets the hex encoded SHA256 hash from a generated population protobuf output given input and rng.
+async fn population_protobuf_hash(input: &Input, dir: &str, mut rng: StdRng) -> Result<String> {
+    let (population, _) = Population::create(input.clone(), &mut rng).await?;
     std::fs::create_dir_all(dir).unwrap();
     let output = format!("{dir}/population.pb");
     protobuf::convert_to_pb(&population, output.clone())?;
-    Ok(Base64::encode_string(&Sha256::digest(
-        std::fs::read(output).unwrap(),
-    )))
+    Ok(hex::encode(Sha256::digest(std::fs::read(output).unwrap())))
 }
 
 #[tokio::test]

--- a/tests/determinism.rs
+++ b/tests/determinism.rs
@@ -18,6 +18,7 @@ async fn population_protobuf_hash(input: &Input, dir: &str, mut rng: StdRng) -> 
     Ok(hex::encode(Sha256::digest(std::fs::read(output).unwrap())))
 }
 
+// To run: `cargo test --release -- --include-ignored`
 #[tokio::test]
 #[ignore = "requires data retrieval."]
 async fn test_determinism() -> Result<()> {

--- a/tests/determinism.rs
+++ b/tests/determinism.rs
@@ -1,0 +1,75 @@
+use base64ct::{Base64, Encoding};
+use fs_err::File;
+use rand::rngs::StdRng;
+use rand::SeedableRng;
+use sha2::{Digest, Sha256};
+use spc::{protobuf, Input, Population, MSOA};
+use std::collections::BTreeSet;
+use std::io::{BufRead, BufReader};
+// use tracing::{info, info_span};
+
+#[tokio::test]
+#[ignore = "requires data retrieval."]
+async fn test_determinism() -> anyhow::Result<()> {
+    spc::tracing_span_tree::SpanTree::new().enable();
+    let seed = 0;
+    let tmp_path = tempfile::tempdir()
+        .unwrap()
+        .path()
+        .as_os_str()
+        .to_str()
+        .unwrap()
+        .to_string();
+    // let mut rng = StdRng::seed_from_u64(seed);
+    let msoas = BTreeSet::new();
+    let mut input = Input {
+        year: 2020,
+        filter_empty_msoas: false,
+        enable_commuting: true,
+        sic_threshold: 0.,
+        msoas,
+    };
+    let country: &str = "England";
+    let region: &str = "rutland";
+    let input_path: &str = &format!("config/{country}/{region}.txt");
+    BufReader::new(File::open(input_path)?)
+        .lines()
+        .for_each(|line| {
+            input
+                .msoas
+                .insert(MSOA(line.unwrap().trim_matches('"').to_string()));
+        });
+
+    // Run 1 with seed
+    let (population, _) =
+        Population::create(input.clone(), &mut StdRng::seed_from_u64(seed)).await?;
+    let dir = format!("{tmp_path}/data/output/{country}/{}", population.year);
+    std::fs::create_dir_all(&dir).unwrap();
+    let output = format!("{dir}/{region}{}.pb", 1);
+    protobuf::convert_to_pb(&population, output.clone())?;
+    let hash1 = Base64::encode_string(&Sha256::digest(std::fs::read(output).unwrap()));
+
+    // Run 2 with same seed
+    let (population, _) =
+        Population::create(input.clone(), &mut StdRng::seed_from_u64(seed)).await?;
+    let dir = format!("{tmp_path}/data/output/{country}/{}", population.year);
+    std::fs::create_dir_all(&dir).unwrap();
+    let output = format!("{dir}/{region}{}.pb", 2);
+    protobuf::convert_to_pb(&population, output.clone())?;
+    let hash2 = Base64::encode_string(&Sha256::digest(std::fs::read(output).unwrap()));
+
+    assert_eq!(hash1, hash2);
+
+    // Run 3 with different seed
+    let seed_diff = 1u64;
+    let (population, _) = Population::create(input, &mut StdRng::seed_from_u64(seed_diff)).await?;
+    let dir = format!("{tmp_path}/data/output/{country}/{}", population.year);
+    std::fs::create_dir_all(&dir).unwrap();
+    let output = format!("{dir}/{region}{}.pb", 3);
+    protobuf::convert_to_pb(&population, output.clone())?;
+    let hash3 = Base64::encode_string(&Sha256::digest(std::fs::read(output).unwrap()));
+
+    assert!(hash1 != hash3);
+
+    Ok(())
+}


### PR DESCRIPTION
Closes #52.

This PR ensures protobuf outputs are deterministic for a given seed by:
- Using `BTreeMap` over `HashMap` as `venues_per_sic` is looped over non-determininistically with `HashMap` (see [comment](https://github.com/alan-turing-institute/uatk-spc/issues/52#issuecomment-1523530461)).
- Configuring prost to serialize with `BTreeMap` over `HashMap` (see [comment](https://github.com/alan-turing-institute/uatk-spc/issues/52#issuecomment-1525191112)).
- Adding [integration test](https://github.com/alan-turing-institute/uatk-spc/blob/49d978276aaa6630ed1f8bcb63536efb26e2b2f4/tests/determinism.rs) for equality and inequality of the SHA256 file hashes upon population generation.

A [script](https://github.com/alan-turing-institute/uatk-spc/blob/cbe06a4aad8d8338fc6577b5329b9c33c8978a96/scripts/check_determinism.sh) is also added for comparing any given region with diff on JSON printed when outputs differ.