### PR TITLE
Add GHA workflow to publish from improved_doc branch

### DIFF
--- a/.github/workflows/pages_improved_doc.yml
+++ b/.github/workflows/pages_improved_doc.yml
@@ -1,0 +1,40 @@
+name: Deploy site
+
+on: [push]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Install quarto
+      uses: quarto-dev/quarto-actions/setup@v2
+      with:
+        tinytex: true
+
+    - name: Render site
+      run: |
+        cd docs
+        quarto render --to all --output-dir ./_book_improved_docs
+
+    - name: Install node
+      uses: actions/setup-node@v2
+      with:
+        node-version: 18.x
+        cache: 'npm'
+        cache-dependency-path: web/package-lock.json
+
+    - name: Build web app
+      run: |
+        cd web
+        npm ci
+        npm run build --if-present -- --outDir='dist_improved_docs'
+        mv dist_improved_docs ../docs/_book_improved_docs/app
+
+    - name: Publish
+      uses: peaceiris/actions-gh-pages@v3
+      with:
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+        publish_dir: ./docs/_book_improved_docs
+        destination_dir: improved_docs


### PR DESCRIPTION
@HSalat following on from earlier... I don't have push rights to the SPC repository (which is fine), but I think if you merge this, it'll be added to the existing PR (#61).

After this is merged, any time someone pushes to the `improved_doc` branch, the new docs will be built @ https://alan-turing-institute.github.io/uatk-spc/improved_doc 🙂 