### PR TITLE
Fix OSM URLs

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,7 +17,7 @@ jobs:
     steps:
       - uses: actions/checkout@master
 
-      - uses: hecrj/setup-rust-action@v1
+      - uses: hecrj/setup-rust-action@v2
         with:
           rust-version: stable
 
@@ -27,7 +27,7 @@ jobs:
                 repo-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Cache build
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
                 path: target
                 # The key could include hashFiles('Cargo.lock'), but cargo will figure out what can be reused.
@@ -55,7 +55,7 @@ jobs:
 
     steps:
     - name: Checkout Code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
       with:
         fetch-depth: 0
 
@@ -77,7 +77,7 @@ jobs:
         python -m poetry config virtualenvs.in-project true
 
     - name: Set up cache
-      uses: actions/cache@v2
+      uses: actions/cache@v4
       id: cache
       with:
         path: .venv

--- a/scripts/data_prep/raw_to_prepared.R
+++ b/scripts/data_prep/raw_to_prepared.R
@@ -975,6 +975,11 @@ rownames(oatoOtherS) <- 1:nrow(oatoOtherS)
 oatoOther <- rbind(oatoOtherEW,oatoOtherS)
 rownames(oatoOther) <- 1:nrow(oatoOther)
 
+# Replace 'great-britain' with 'united-kingdom' in OSM URLs
+# See: https://github.com/alan-turing-institute/uatk-spc/issues/73
+oatoOther <- oatoOther %>%
+  mutate(OSM = gsub("/great-britain/", "/united-kingdom/", OSM))
+
 # Output
 print("Writing outputs...")
 write.table(oatoOther,paste(folderOut,"lookUp-GB.csv",sep = ""),row.names = F, sep = ",")


### PR DESCRIPTION
Closes #73.

This PR:
- replaces the "/great-britain/" with "/united-kingdom/" is the OSM URLs for constructing the lookup that is used downstream by the Rust code for downloading data
- updates deprecated/outdated actions